### PR TITLE
fix(ci): update documentation link for GitHub credentials in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           release-type: simple
           # Needed to CI checks to execute en Release Please PRs
-          # See: https://github.com/google-github-actions/release-please-action#github-credentials
+          # See: https://github.com/googleapis/release-please-action#github-credentials
           token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/release.yaml` file to correct a URL in the comment section.

* Corrected the URL in the comment to point to the updated `release-please-action` documentation.