### PR TITLE
chore: add fmt and fmt-check shfmt-based tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: test
+name: ci
 on:
   pull_request:
   merge_group:
@@ -16,16 +16,26 @@ env:
   sops-version: 3.11.0
 
 jobs:
+  fmt-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Setup just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Install shfmt
+        run: sudo apt-get install -y shfmt
+
+      - run: just fmt-check
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Setup shellcheck
-        run: sudo apt-get install -y shellcheck
-
-      - name: Setup yamllint
-        run: sudo apt-get install -y yamllint
+      - name: Install shellcheck and yamllint
+        run: sudo apt-get install -y shellcheck yamllint
 
       - name: Setup just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
@@ -53,9 +63,11 @@ jobs:
         with:
           version: ${{ env.sops-version }}
 
+      # Validate testlib
       - run: just check-testlib
       - run: just test-testlib
 
+      # Validate action code
       - run: just check
       - run: just unittest
       - run: just inttest

--- a/action.sh
+++ b/action.sh
@@ -26,10 +26,10 @@
 #   STDOUT - The output of the command
 #   STDERR - details, on failure
 _sops::exec_env() {
-  local env_file=$1
-  local command=$2
+	local env_file=$1
+	local command=$2
 
-  sops exec-env "$env_file" "$command"
+	sops exec-env "$env_file" "$command"
 }
 
 # The pre-requisite checks for the action.
@@ -53,7 +53,7 @@ action::check_pre_requisites() {
 
 	# Check if 'gpg' is installed and get the version
 	local gpg_version
-	if ! command -v gpg &> /dev/null; then
+	if ! command -v gpg &>/dev/null; then
 		gpg_version="none"
 	else
 		gpg_version="$(gpg --version | awk 'NR==1{print $3}')"
@@ -67,14 +67,14 @@ action::check_pre_requisites() {
 
 	# Check if 'age' is installed and get the version
 	local age_version
-	if ! command -v age &> /dev/null; then
+	if ! command -v age &>/dev/null; then
 		age_version="none"
 	else
 		age_version="$(age --version | sed 's/^v//')"
 	fi
 
 	# Write the 'age' version to a GitHub output variable
-	echo "age-version=$age_version" >> "$GITHUB_OUTPUT"
+	echo "age-version=$age_version" >>"$GITHUB_OUTPUT"
 
 	# Fail if the 'age' key is set and 'age' is not installed
 	if [[ -n "$SOPS_AGE_KEY_FILE" || -n "$SOPS_AGE_KEY" ]] && [[ "$age_version" == 'none' ]]; then
@@ -84,7 +84,7 @@ action::check_pre_requisites() {
 
 	# Fail if 'sops' is not installed
 	local sops_version
-	if ! command -v sops &> /dev/null; then
+	if ! command -v sops &>/dev/null; then
 		echo "sops not found in PATH. Please install sops." >&2
 		return 1
 	else
@@ -92,20 +92,24 @@ action::check_pre_requisites() {
 	fi
 
 	# Write the version as GitHub output variables
-	{ echo "gpg-version=$gpg_version"; echo "age-version=$age_version"; echo "sops-version=$sops_version"; } >> "$GITHUB_OUTPUT"
+	{
+		echo "gpg-version=$gpg_version"
+		echo "age-version=$age_version"
+		echo "sops-version=$sops_version"
+	} >>"$GITHUB_OUTPUT"
 }
 
 # The entrypoint for the action.
 action::main() {
-  local env_file=$1
-  local command=$2
+	local env_file=$1
+	local command=$2
 
-  # Check if file exists
-  if [[ ! -f "$env_file" ]]; then
-	echo "Environment file not found: $env_file" >&2
-	return 1
-  fi
+	# Check if file exists
+	if [[ ! -f "$env_file" ]]; then
+		echo "Environment file not found: $env_file" >&2
+		return 1
+	fi
 
-  # Decrypt and inject the environment variables to the command
-  _sops::exec_env "$env_file" "$command"
+	# Decrypt and inject the environment variables to the command
+	_sops::exec_env "$env_file" "$command"
 }

--- a/test/action_age_encryption.test.bats
+++ b/test/action_age_encryption.test.bats
@@ -19,7 +19,6 @@ setup() {
 	source "$DIR/../action.sh"
 }
 
-
 @test 'action::age::exec command with environment' {
 	## Given
 	# Create a temporary directory
@@ -30,9 +29,9 @@ setup() {
 	local env_file
 	env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -74,9 +73,9 @@ setup() {
 	local env_file
 	env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -118,9 +117,9 @@ setup() {
 	local env_file
 	env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -162,9 +161,9 @@ setup() {
 	local env_file
 	env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -195,5 +194,3 @@ setup() {
 	# Remove the temporary directory
 	temp_del "$temp_dir"
 }
-
-

--- a/test/action_gpg_encryption.test.bats
+++ b/test/action_gpg_encryption.test.bats
@@ -19,7 +19,6 @@ setup() {
 	source "$DIR/../action.sh"
 }
 
-
 @test 'action::gpg::exec command with environment' {
 	## Setup
 	# Create a temporary directory
@@ -34,9 +33,9 @@ setup() {
 	# Create a new test environment file.
 	local env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -85,9 +84,9 @@ setup() {
 	# Create a new test environment file.
 	local env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -136,9 +135,9 @@ setup() {
 	# Create a new test environment file.
 	local env_file="$temp_dir/.env"
 
-	cat <<-EOF > "$env_file"
-	SECRET_KEY=YOURSECRETKEYGOESHERE
-	SECRET_HASH=something-with-a-#-hash
+	cat <<-EOF >"$env_file"
+		SECRET_KEY=YOURSECRETKEYGOESHERE
+		SECRET_HASH=something-with-a-#-hash
 	EOF
 
 	# Define the test command
@@ -172,5 +171,3 @@ setup() {
 	# Remove the temporary directory
 	temp_del "$temp_dir"
 }
-
-

--- a/test/testlib/age/keygen.bash
+++ b/test/testlib/age/keygen.bash
@@ -21,7 +21,6 @@ age::unset_env() {
 	unset -v AGE_KEY_FILE
 }
 
-
 # Use 'age-keygen' to generate a keypair. If no key file is provided, a temporary file will be created.
 #
 # If the keypair is successfully generated, the following environment variables will be set:

--- a/test/testlib/gpg/keygen.bash
+++ b/test/testlib/gpg/keygen.bash
@@ -50,23 +50,23 @@ gpg::generate_keypair() {
 	user_name="Test User $user_id"
 	user_email="test-$user_id@example.com"
 
-	cat <<-EOF > "$gnupg_home/keygen_details"
-	%echo Generating a test OpenPGP key
-	Key-Type: RSA
-	Key-Length: 4096
-	Subkey-Type: RSA
-	Subkey-Length: 4096
-	Name-Real: ${user_name}
-	Name-Comment: with no passphrase
-	Name-Email: ${user_email}
-	Expire-Date: 0
-	%no-ask-passphrase
-	%no-protection
-	# Do a commit here, so that we can later print "done"
-	%commit
-	%echo done
+	cat <<-EOF >"$gnupg_home/keygen_details"
+		%echo Generating a test OpenPGP key
+		Key-Type: RSA
+		Key-Length: 4096
+		Subkey-Type: RSA
+		Subkey-Length: 4096
+		Name-Real: ${user_name}
+		Name-Comment: with no passphrase
+		Name-Email: ${user_email}
+		Expire-Date: 0
+		%no-ask-passphrase
+		%no-protection
+		# Do a commit here, so that we can later print "done"
+		%commit
+		%echo done
 	EOF
-	if ! gpg --homedir "$gnupg_home" --verbose --batch --gen-key "$gnupg_home/keygen_details" 2> /dev/null; then
+	if ! gpg --homedir "$gnupg_home" --verbose --batch --gen-key "$gnupg_home/keygen_details" 2>/dev/null; then
 		echo "Keypair generation failed" >&2
 		temp_del "$gnupg_home"
 		return 1
@@ -80,7 +80,6 @@ gpg::generate_keypair() {
 	local private_key
 	public_key=$(gpg --homedir "$gnupg_home" --armor --export "$user_email")
 	private_key=$(gpg --homedir "$gnupg_home" --armor --export-secret-keys "$user_email")
-
 
 	# Export the private key to a file
 	gpg --homedir "$gnupg_home" --armor --export-secret-keys --output "$key_file" "$user_email"

--- a/test/testlib/gpg/keystore.bash
+++ b/test/testlib/gpg/keystore.bash
@@ -99,7 +99,7 @@ gpg::import_key() {
 	fi
 
 	# Import the keypair
-	if ! gpg --homedir "$gpg_home_dir" --batch --import --yes <<< "$key" 2> /dev/null; then
+	if ! gpg --homedir "$gpg_home_dir" --batch --import --yes <<<"$key" 2>/dev/null; then
 		echo "Keypair import failed" >&2
 
 		# Clean up the temporary directory if it was created
@@ -154,7 +154,7 @@ gpg::import_key_file() {
 	fi
 
 	# Import the keypair
-	if ! gpg --homedir "$gpg_home_dir" --batch --import --yes "$key_file" 2> /dev/null; then
+	if ! gpg --homedir "$gpg_home_dir" --batch --import --yes "$key_file" 2>/dev/null; then
 		echo "Keypair import failed" >&2
 
 		# Clean up the temporary directory if it was created

--- a/test/testlib/sops/age.bash
+++ b/test/testlib/sops/age.bash
@@ -18,10 +18,10 @@
 #   STDOUT - The encrypted file
 #   STDERR - details, on failure
 sops::encrypt_with_age() {
-    local public_key="$1"
-    local file="$2"
+	local public_key="$1"
+	local file="$2"
 
-    sops --age "$public_key" --encrypt "$file"
+	sops --age "$public_key" --encrypt "$file"
 }
 
 # Use 'sops' to encrypt a file using an 'age' key in place, i.e., overwrite the file
@@ -41,14 +41,13 @@ sops::encrypt_with_age() {
 # Outputs:
 #   STDERR - details, on failure
 sops::encrypt_in_place_with_age() {
-    local public_key="$1"
-    local file="$2"
+	local public_key="$1"
+	local file="$2"
 
-    # NB: The '--in-place' flag must be provided before '--encrypt',
-    #     otherwise it is ignored.
-    sops --age "$public_key" --in-place --encrypt "$file"
+	# NB: The '--in-place' flag must be provided before '--encrypt',
+	#     otherwise it is ignored.
+	sops --age "$public_key" --in-place --encrypt "$file"
 }
-
 
 # Use 'sops' to decrypt a file using an 'age' key.
 #
@@ -67,10 +66,10 @@ sops::encrypt_in_place_with_age() {
 #   STDOUT - The decrypted file
 #   STDERR - details, on failure
 sops::decrypt_with_age() {
-    local private_key="$1"
-    local file="$2"
+	local private_key="$1"
+	local file="$2"
 
-    env SOPS_AGE_KEY="$private_key" sops --decrypt "$file"
+	env SOPS_AGE_KEY="$private_key" sops --decrypt "$file"
 }
 
 # Use 'sops' to decrypt a file using an 'age' key in place, i.e., overwrite the file
@@ -90,10 +89,10 @@ sops::decrypt_with_age() {
 # Outputs:
 #   STDERR - details, on failure
 sops::decrypt_in_place_with_age() {
-    local private_key="$1"
-    local file="$2"
+	local private_key="$1"
+	local file="$2"
 
-    # NB: The '--in-place' flag must be provided before '--decrypt',
-    #     otherwise it is ignored.
-    env SOPS_AGE_KEY="$private_key" sops --in-place --decrypt "$file"
+	# NB: The '--in-place' flag must be provided before '--decrypt',
+	#     otherwise it is ignored.
+	env SOPS_AGE_KEY="$private_key" sops --in-place --decrypt "$file"
 }

--- a/test/testlib/sops/gpg.bash
+++ b/test/testlib/sops/gpg.bash
@@ -24,11 +24,11 @@
 #   STDOUT - The encrypted file
 #   STDERR - details, on failure
 sops::encrypt_with_gpg() {
-    local public_key="$1"
-    local file="$2"
-    local gpg_home_dir="${3:-$GPG_HOME_DIR}"
+	local public_key="$1"
+	local file="$2"
+	local gpg_home_dir="${3:-$GPG_HOME_DIR}"
 
-    env GNUPGHOME="$gpg_home_dir" sops --pgp "$public_key" --encrypt "$file"
+	env GNUPGHOME="$gpg_home_dir" sops --pgp "$public_key" --encrypt "$file"
 }
 
 # Use 'sops' to encrypt a file using an 'gpg' key in place, i.e., overwrite the file
@@ -54,15 +54,14 @@ sops::encrypt_with_gpg() {
 # Outputs:
 #   STDERR - details, on failure
 sops::encrypt_in_place_with_gpg() {
-    local fingerprint="$1"
-    local file="$2"
-    local gpg_home_dir="${3:-$GPG_HOME_DIR}"
+	local fingerprint="$1"
+	local file="$2"
+	local gpg_home_dir="${3:-$GPG_HOME_DIR}"
 
-    # NB: The '--in-place' flag must be provided before '--encrypt',
-    #     otherwise it is ignored.
-    env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --in-place --encrypt "$file"
+	# NB: The '--in-place' flag must be provided before '--encrypt',
+	#     otherwise it is ignored.
+	env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --in-place --encrypt "$file"
 }
-
 
 # Use 'sops' to decrypt a file using an 'gpg' key.
 #
@@ -87,11 +86,11 @@ sops::encrypt_in_place_with_gpg() {
 #   STDOUT - The decrypted file
 #   STDERR - details, on failure
 sops::decrypt_with_gpg() {
-    local fingerprint="$1"
-    local file="$2"
-    local gpg_home_dir="${3:-$GPG_HOME_DIR}"
+	local fingerprint="$1"
+	local file="$2"
+	local gpg_home_dir="${3:-$GPG_HOME_DIR}"
 
-    env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --decrypt "$file"
+	env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --decrypt "$file"
 }
 
 # Use 'sops' to decrypt a file using an 'gpg' key in place, i.e., overwrite the file
@@ -117,11 +116,11 @@ sops::decrypt_with_gpg() {
 # Outputs:
 #   STDERR - details, on failure
 sops::decrypt_in_place_with_gpg() {
-    local fingerprint="$1"
-    local file="$2"
-    local gpg_home_dir="${3:-$GPG_HOME_DIR}"
+	local fingerprint="$1"
+	local file="$2"
+	local gpg_home_dir="${3:-$GPG_HOME_DIR}"
 
-    # NB: The '--in-place' flag must be provided before '--decrypt',
-    #     otherwise it is ignored.
-    env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --in-place --decrypt "$file"
+	# NB: The '--in-place' flag must be provided before '--decrypt',
+	#     otherwise it is ignored.
+	env GNUPGHOME="$gpg_home_dir" sops --pgp "$fingerprint" --in-place --decrypt "$file"
 }

--- a/test/testlib/sops/test/age.test.bats
+++ b/test/testlib/sops/test/age.test.bats
@@ -19,10 +19,10 @@ setup() {
 function new_test_env_file() {
 	local dest_file="$1"
 
-	cat <<-EOF > "$dest_file"
-	# This is a comment
-	SECRET_KEY=YOURSECRETKEYGOESHERE # comment
-	SECRET_HASH="something-with-a-#-hash"
+	cat <<-EOF >"$dest_file"
+		# This is a comment
+		SECRET_KEY=YOURSECRETKEYGOESHERE # comment
+		SECRET_HASH="something-with-a-#-hash"
 	EOF
 }
 
@@ -70,7 +70,6 @@ function assert_file_is_not_encrypted() {
 	return 0
 }
 
-
 @test 'sops::files::it should encrypt the environment file' {
 	## Setup
 	local temp_dir
@@ -89,7 +88,7 @@ function assert_file_is_not_encrypted() {
 	local encrypted_file
 	encrypted_file="$env_file.encrypted"
 
-	sops::encrypt_with_age "$AGE_PUBLIC_KEY" "$env_file" > "$encrypted_file"
+	sops::encrypt_with_age "$AGE_PUBLIC_KEY" "$env_file" >"$encrypted_file"
 
 	## Then
 	assert [ $? -eq 0 ]
@@ -120,7 +119,7 @@ function assert_file_is_not_encrypted() {
 	## When
 	local decrypted_file
 	decrypted_file="$env_file.decrypted"
-	sops::decrypt_with_age "$AGE_SECRET_KEY" "$env_file" > "$decrypted_file"
+	sops::decrypt_with_age "$AGE_SECRET_KEY" "$env_file" >"$decrypted_file"
 
 	## Then
 	assert [ $? -eq 0 ]

--- a/test/testlib/sops/test/gpg.test.bats
+++ b/test/testlib/sops/test/gpg.test.bats
@@ -19,10 +19,10 @@ setup() {
 function new_test_env_file() {
 	local dest_file="$1"
 
-	cat <<-EOF > "$dest_file"
-	# This is a comment
-	SECRET_KEY=YOURSECRETKEYGOESHERE # comment
-	SECRET_HASH="something-with-a-#-hash"
+	cat <<-EOF >"$dest_file"
+		# This is a comment
+		SECRET_KEY=YOURSECRETKEYGOESHERE # comment
+		SECRET_HASH="something-with-a-#-hash"
 	EOF
 }
 
@@ -70,7 +70,6 @@ function assert_file_is_not_encrypted() {
 	return 0
 }
 
-
 @test 'sops::files::it should encrypt the environment file' {
 	## Setup
 	local temp_dir
@@ -96,7 +95,7 @@ function assert_file_is_not_encrypted() {
 	local encrypted_file
 	encrypted_file="$env_file.encrypted"
 
-	sops::encrypt_with_gpg "$GPG_KEY_FP" "$env_file" "$gpg_home_dir" > "$encrypted_file"
+	sops::encrypt_with_gpg "$GPG_KEY_FP" "$env_file" "$gpg_home_dir" >"$encrypted_file"
 
 	## Then
 	assert [ $? -eq 0 ]
@@ -134,7 +133,7 @@ function assert_file_is_not_encrypted() {
 	## When
 	local decrypted_file
 	decrypted_file="$env_file.decrypted"
-	sops::decrypt_with_gpg "$GPG_SECRET_KEY" "$env_file" "$gpg_home_dir" > "$decrypted_file"
+	sops::decrypt_with_gpg "$GPG_SECRET_KEY" "$env_file" "$gpg_home_dir" >"$decrypted_file"
 
 	## Then
 	assert [ $? -eq 0 ]


### PR DESCRIPTION
Add shell formatting checks to the CI pipeline using `shfmt` and reorganize the Justfile with dedicated format tasks.

- Add `fmt` and `fmt-check` tasks to `justfile` for formatting shell scripts and BATS files
- Format all shell files (`action.sh`, testlib scripts, BATS test files) using `shfmt --indent 0`
- Rename `.github/workflows/test.yaml` to `ci.yaml` and update workflow name to "ci"
- Add `fmt-check` job to CI workflow for shell formatting validation